### PR TITLE
readme: add shallow clone option

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -11,6 +11,10 @@ To initialize your local repository using the LineageOS trees, use a command lik
 ```
 repo init -u https://github.com/LineageOS-Revived/android.git -b lineage-17.1 --git-lfs
 ```
+Or Initialize Shallow Clone
+```
+repo init --depth=1 -u https://github.com/LineageOS-Revived/android.git -b lineage-17.1 --git-lfs
+```
 Then to sync up:
 ```
 repo sync


### PR DESCRIPTION
Although this doesn't strictly adhere to upstream, it's a useful and convenient addition